### PR TITLE
Mix version is expected to be a SemVer version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Whisk.Mixfile do
 
 	def project do
 		[app: :whisk,
-		 version: "1",
+		 version: "1.0.0",
 		 elixir: "~> 1.2",
 		 build_embedded: Mix.env == :prod,
 		 start_permanent: Mix.env == :prod,


### PR DESCRIPTION
When compiling whisk as a dependency of wok_i18n in a mix project, the version not respecting semver causes the following error at compile time:

`** (Mix) Expected :version to be a SemVer version`
